### PR TITLE
Fixing issues with ports != 80

### DIFF
--- a/charcoal/tcptest.py
+++ b/charcoal/tcptest.py
@@ -2,6 +2,8 @@
 import logging
 import socket
 from retrying import retry
+from .colours import COLOURS
+
 
 FORMAT = '%(asctime)-15s %(name)s [%(levelname)s]: %(message)s'
 logging.basicConfig(format=FORMAT, level=logging.ERROR, datefmt="%Y-%m-%d %H:%M:%S")
@@ -21,13 +23,15 @@ def tcp_test(host, port):
         my_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         my_sock.settimeout(1)
         my_sock.connect((host, port))
-        print("Connecting to {0} on port {1} [PASS]".format(host, port))
+        print("Connecting to {0} on port {1} {2}".format(host, port, COLOURS.to_green("[PASS]")))
         my_sock.shutdown(2)
         my_sock.close()
     except socket.error:
         my_sock.close()
+        print("Connecting to {0} on port {1} {2}".format(host, port, COLOURS.to_yellow("[FAIL]")))
         LOG.debug("Waiting for {0}:{1} to accept a connection".format(host, port))
         raise
     except Exception as error:
+        print("Connecting to {0} on port {1} {2}".format(host, port, COLOURS.to_yellow("[FAIL]")))
         LOG.debug("TCP test failed: {0}".format(error))
         raise

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ with open('HISTORY', 'r') as f:
 
 setup(
     name='smolder',
-    version='0.2.2',
+    version='0.2.3',
     description='Json wrapper around requests for simple smoke testing.',
     long_description=README + '\n\n' + HISTORY,
     author='Max Cameron',

--- a/smolder
+++ b/smolder
@@ -111,14 +111,16 @@ def smolder_cli(**kwargs):
         LOG.error("There are no tests configured in %s: You need at least one test", kwargs['testfile'])
         sys.exit(2)
 
-    LOG.debug("Beginning default TCP test")
-    port = getattr(tests[0], 'port', 80)
-    tcp_test(str(kwargs['host']), port)
-    LOG.debug("Passed default TCP test")
     print("Preparing to execute {0} tests".format(len(tests)))
     # Iterate through all the tests
 
     for test in test_input['tests']:
+        try:
+            port = test["port"]
+        except (AttributeError, KeyError):
+            print("Warning: No port definition found in the first test, using port 80 as default.")
+            port = 80
+        tcp_test(str(kwargs['host']), port)
         test_obj = Charcoal(test=test, host=kwargs['host'])
         print(str(test_obj))
         total_failed_tests += test_obj.failed

--- a/tests/smolder_tests.py
+++ b/tests/smolder_tests.py
@@ -87,6 +87,7 @@ def test_invalid_yaml_format():
         total_passed_tests += test_obj.passed
     assert total_failed_tests == 0
 
+
 def test_tcp_test():
     smolder.tcp_test('127.0.0.1', 22)  # Are you running an ssh server?
 


### PR DESCRIPTION
This bug meant that if your first test defined a port which was not port 80, smolder would test for connectivity on port 80 instead of what you wanted and if you were not running port 80, then smolder would bail without running your other tests. 

Now: we test tcp connectivity for every test you provide, we don't use getattr and more reliably detect when you haven't provided a port for us to test.  We also provide output for every tcp test retry and include the details we are testing.

The tcp testing function is covered by unit tests, however the code that calls it isn't (since we would need to shell out for that, and I'm not sure that's a good idea).  Suggestions and pull requests welcome.
