### PR TITLE
Handle the three cases involded in verifying ssl

### DIFF
--- a/charcoal/charcoal.py
+++ b/charcoal/charcoal.py
@@ -97,7 +97,10 @@ class Charcoal(object):
                     test_out = '%10s: %s' % ("SecureRequest", self.fail_test("Insecure request made"))
                     self.output = "\n".join([self.output, test_out])
                 else:
-                    test_out = '%10s: %s' % ("SecureRequest", self.fail_test("Insecure request made: add verify to your test['input']"))
+                    test_out = '%10s: %s' % ("SecureRequest", self.pass_test("Insecure request made and ignored"))
+                    self.output = "\n".join([self.output, test_out])
+                if 'verify' not in self.test['inputs']:
+                    test_out = '%10s: %s' % ("SecureRequest", self.fail_test("Insecure request not ignored by 'verify'"))
                     self.output = "\n".join([self.output, test_out])
 
         if 'show_body' in self.test:


### PR DESCRIPTION
I'm making an ssl request to a service that is insecure, and I want to acknowledge that and have tests pass.  Adding 'verify': False to the test input, I'm seeing:

```
    SecureRequest: ("Insecure request made: add verify to your test['input']", '\x1b[91m[FAIL]\x1b[0m')
```

We should fail if verify is True and the request is insecure, and if there is no 'verify' added to the test.  We should pass if verify is False and the request is insecure.
