### PR TITLE
Catch SSLErrors and re-request dropping warnings.

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -2,10 +2,16 @@ RELEASE HISTORY
 ===============
 
 
+Version 0.4.2
+-------------
+- More specific SSL error handling
+- Schema validation happens inside the class for Ansible module support
+
 Version 0.4.1
 -------------
 - Adds error handling for bad ssl certificates.
 - Unit tests in place for all types of bad ssl certificates currently handled by badssl.com
+- New plugin "response_header_value_contains", big thanks to https://github.com/yasn77
 
 Version 0.4.0
 -------------
@@ -16,7 +22,7 @@ Version 0.3.1
 - Adds support for default overrides
 - Supporting Docker testing
 - Community contributions
-- Big thanks to github.com/hekaldama
+- Big thanks to https://github.com/hekaldama
 
 Version 0.3.0
 -------------

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Smolder aims to solve these problems by providing features such as:
 - Validate ssl certificates.
 - Validate headers.
 - Validate json object types using [validictory](https://github.com/jamesturk/validictory)
+- Write plugins using [Yapsy](https://github.com/tibonihoo/yapsy)
 - More
 
 Installation

--- a/charcoal/charcoal.py
+++ b/charcoal/charcoal.py
@@ -189,21 +189,21 @@ class Charcoal(object):
             try:
                 LOG.debug("Verify is a: {0}, with value: {1}".format(type(self.verify), self.verify))
                 start = int(round(time.time() * 1000))
-                self.req = getattr(requests, self.test['method'].lower())(verify=self.verify, **self.inputs)
-                end = int(round(time.time() * 1000))
-                self.duration_ms = end - start
-            except Exception:
-                warnings.simplefilter("ignore")
-                start = int(round(time.time() * 1000))
                 if self.test["protocol"] != 'tcp':
-                    try:
-                        self.req = getattr(requests, self.test['method'].lower())(verify=self.verify, **self.inputs)
-                    except requests.exceptions.SSLError:
-                        message, status = self.fail_test("Certificate verify failed and not ignored by inputs['verify']")
-                        self.add_output("SSLVerify", message, status)
-                        return
+                    self.req = getattr(requests, self.test['method'].lower())(verify=self.verify, **self.inputs)
                 else:
                     tcptest.tcp_test(self.host, self.port)
+                end = int(round(time.time() * 1000))
+                self.duration_ms = end - start
+            except (RuntimeWarning, requests.exceptions.SSLError):
+                warnings.simplefilter("ignore")
+                start = int(round(time.time() * 1000))
+                try:
+                    self.req = getattr(requests, self.test['method'].lower())(verify=self.verify, **self.inputs)
+                except requests.exceptions.SSLError:
+                    message, status = self.fail_test("Certificate verify failed and not ignored by inputs['verify']")
+                    self.add_output("SSLVerify", message, status)
+                    return
                 end = int(round(time.time() * 1000))
                 self.duration_ms = end - start
                 if not self.verify_specified:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ with open('HISTORY', 'r') as f:
 
 setup(
     name='smolder',
-    version='0.4.1',
+    version='0.4.2',
     description='Json wrapper around requests for simple smoke testing.',
     long_description=README + '\n\n' + HISTORY,
     author='Max Cameron',


### PR DESCRIPTION
This excludes other exceptions from being caught by the warning filter.
Tcp requests made in the first attempt.
