### PR TITLE
Disable SSLVerify exceptions when verify is off

### DIFF
--- a/charcoal/charcoal.py
+++ b/charcoal/charcoal.py
@@ -187,9 +187,10 @@ class Charcoal(object):
 
     def run(self):
         with warnings.catch_warnings():
-            warnings.simplefilter("error")
             try:
                 LOG.debug("Verify is a: {0}, with value: {1}".format(type(self.verify), self.verify))
+                if self.verify:
+                    warnings.simplefilter("error", requests.exceptions.SSLError)
                 start = int(round(time.time() * 1000))
                 if self.test["protocol"] != 'tcp':
                     self.req = requests.request(self.test['method'].upper(), verify=self.verify, **self.inputs)
@@ -198,12 +199,12 @@ class Charcoal(object):
                 end = int(round(time.time() * 1000))
                 self.duration_ms = end - start
             except (RuntimeWarning, requests.exceptions.SSLError):
-                warnings.simplefilter("ignore")
+                warnings.simplefilter("default", requests.exceptions.SSLError)
                 start = int(round(time.time() * 1000))
                 try:
                     self.req = requests.request(self.test['method'].upper(), verify=self.verify, **self.inputs)
-                except requests.exceptions.SSLError:
-                    message, status = self.fail_test("Certificate verify failed and not ignored by inputs['verify']")
+                except (requests.exceptions.SSLError) as e:
+                    message, status = self.fail_test("Certificate verify failed and not ignored by inputs['verify']: %s" % (str(e)))
                     self.add_output("SSLVerify", message, status)
                     return
                 end = int(round(time.time() * 1000))


### PR DESCRIPTION
When verify is false, an exception will still be raised and smolder fails.

This happens because requests issues a warning when verify is off, and enabling errors for warnings causes them to raise exceptions. This should not happen.

I also added a bit of code to print the exception message for easier debugging.
